### PR TITLE
Update sysctl.sh

### DIFF
--- a/files/sysctl.sh
+++ b/files/sysctl.sh
@@ -7,3 +7,4 @@ echo "net.ipv4.conf.default.accept_source_route = 0" |  tee -a /etc/sysctl.conf
 echo "net.ipv4.conf.default.send_redirects = 0" |  tee -a /etc/sysctl.conf
 echo "net.ipv4.icmp_ignore_bogus_error_responses = 1" |  tee -a /etc/sysctl.conf
 sysctl -p
+service procps restart


### PR DESCRIPTION
restart procps service

# defects
on some situations, after enable ip forward and sysctl -p commands,  the network is broken, so the next steps, such as npm install will exit abnormally.   
# solution
at Ubuntu 14.04, restart procps service can fix this problem